### PR TITLE
Add eslint-config-prettier and fix ecmaFeatures error

### DIFF
--- a/config/eslint/.eslintrc-node
+++ b/config/eslint/.eslintrc-node
@@ -1,9 +1,11 @@
 ---
 extends:
   - "walmart/configurations/es6-node"
+  - "prettier"
 
-ecmaFeatures:
-  modules: false
+parserOptions:
+  ecmaFeatures:
+    modules: false
 
 rules:
   "func-style":

--- a/config/eslint/.eslintrc-test
+++ b/config/eslint/.eslintrc-test
@@ -2,11 +2,13 @@
 extends:
   - "walmart/configurations/es6-node"
   - "walmart/configurations/es6-test"
+  - "prettier"
 
 # Turning off modules so that we can use `"use strict";` in tests for things
 # like scoped `let`, etc.
-ecmaFeatures:
-  modules: false
+parserOptions:
+  ecmaFeatures:
+    modules: false
 
 globals:
   expect: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrode-archetype-njs-module-dev",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "main": "arch-clap.js",
   "description": "Archetype for NodeJS Module (Development)",
   "scripts": {},

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-eslint": "^7.1.1",
     "chai": "^3.4.1",
     "eslint": "^3.17.1",
+    "eslint-config-prettier": "^2.3.0",
     "eslint-config-walmart": "^1.1.1",
     "eslint-plugin-filenames": "^1.1.0",
     "mocha": "^3.0.0",


### PR DESCRIPTION
Set [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) to turn off all rules that conflict with prettier. Also nest the `ecmaFeatures` property within `parserOptions` per [eslint migration instructions](http://eslint.org/docs/user-guide/migrating-to-2.0.0#language-options).

CC: @jchip 