### PR TITLE
Update babel-eslint verion to support latest version of eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "arch-clap.js"
   ],
   "dependencies": {
-    "babel-eslint": "^7.1.1",
+    "babel-eslint": "^8.1.2",
     "chai": "^4.1.2",
     "eslint": "^4.8.0",
     "eslint-config-walmart": "^1.1.1",


### PR DESCRIPTION
eslint above 4:14 is incompatible with babel-eslint old versions. Thisissue is solved in babel-eslint version 8.1.2.